### PR TITLE
Develop

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -370,6 +370,54 @@ This page provides working examples of qbit-guard configurations for different d
     !!! danger "Dry Run Mode"
         This configuration runs in dry-run mode and won't actually delete torrents. Perfect for testing.
 
+=== "Fake Torrent Protection"
+
+    **Protection against fake torrents with 0 or very recent age**
+
+    ```yaml
+    version: '3.8'
+
+    services:
+      qbit-guard:
+        image: ghcr.io/gengines/qbit-guard:latest
+        container_name: qbit-guard
+        restart: unless-stopped
+        environment:
+          # qBittorrent connection
+          - QBIT_HOST=http://qbittorrent:8080
+          - QBIT_USER=admin
+          - QBIT_PASS=your_password_here
+          - QBIT_ALLOWED_CATEGORIES=tv-sonarr,radarr
+          
+          # Fake torrent age protection (disabled by default)
+          - MIN_TORRENT_AGE_MINUTES=5
+          
+          # Standard Sonarr pre-air checking
+          - ENABLE_PREAIR_CHECK=1
+          - SONARR_URL=http://sonarr:8989
+          - SONARR_APIKEY=your_sonarr_api_key_here
+          
+          # Radarr integration
+          - RADARR_URL=http://radarr:7878
+          - RADARR_APIKEY=your_radarr_api_key_here
+          
+          # ISO cleanup
+          - ENABLE_ISO_CHECK=1
+          
+          - LOG_LEVEL=INFO
+        networks: [arr-network]
+
+    networks:
+      arr-network: { driver: bridge }
+    ```
+
+    !!! warning "Use with Caution"
+        - **Blocks torrents younger than 5 minutes** (adjustable)
+        - Helps filter fake torrents with 0-age timestamps
+        - **May block legitimate brand-new releases**
+        - Recommended only if experiencing frequent fake torrent issues
+        - Set to `0` to disable (default behavior)
+
 ---
 
 ## :cloud: Kubernetes Examples

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -440,6 +440,45 @@ Example dry-run output:
 
 ## Common Configuration Issues
 
+### Fake Torrents with 0 Age
+
+**Issue**: Indexers returning fake torrents with 0 minutes age or very recent creation dates
+
+**Symptoms**:
+- Torrents appear legitimate but have creation_date timestamp of 0 or just a few minutes old
+- Downloads fail or contain junk content
+- Sonarr/Radarr repeatedly grab the same fake releases
+
+**Solution**: Enable minimum torrent age validation
+
+```yaml
+environment:
+  - MIN_TORRENT_AGE_MINUTES=5  # Block torrents younger than 5 minutes
+```
+
+**Important Considerations**:
+
+!!! warning "Trade-offs"
+    - **Disabled by default** to avoid blocking legitimate brand-new releases
+    - When enabled, torrents younger than the threshold are automatically:
+        - Tagged as `trash:too-new`
+        - Blocklisted in Sonarr/Radarr
+        - Deleted from qBittorrent
+    - Use cautiously if your indexers frequently have brand-new scene releases
+
+**Recommended Values**:
+- `5` - Good balance for most use cases
+- `10` - More aggressive filtering
+- `0` - Disabled (default)
+
+**Log Output**:
+```
+2025-12-22 12:00:00 | INFO | Torrent age check: BLOCKED (age=0.2 mins < minimum=5 mins). Likely fake torrent.
+2025-12-22 12:00:00 | INFO | Removed torrent abc123... (too new/fake, age=0.2 mins).
+```
+
+---
+
 ### Environment Variable Problems
 
 **Issue**: Variables not being read properly

--- a/docs/usage/env.md
+++ b/docs/usage/env.md
@@ -117,6 +117,24 @@ Complete reference of all environment variables supported by qbit-guard, organiz
 
 ---
 
+## Fake Torrent Protection
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MIN_TORRENT_AGE_MINUTES` | `0` | Minimum torrent age in minutes (`0` = disabled, recommended: `5`-`10`) |
+
+!!! warning "Fake Torrent Detection"
+    Fake torrents often have a creation date of 0 minutes or very recent timestamps. Enable this check if you're experiencing issues with fake torrents:
+    
+    - **Disabled by default** (`0`) to avoid blocking legitimate new releases
+    - When enabled (e.g., `MIN_TORRENT_AGE_MINUTES=5`), blocks torrents younger than the specified age
+    - Blocked torrents are tagged as `trash:too-new` and blocklisted in Sonarr/Radarr
+    - Use cautiously: legitimate brand-new releases will also be blocked
+    
+    **Recommended use case**: Enable only if your indexers frequently return fake torrents with 0-age timestamps.
+
+---
+
 ## Extension Policy
 
 | Variable | Default | Description |

--- a/src/guard.py
+++ b/src/guard.py
@@ -181,6 +181,9 @@ class Config:
     metadata_max_wait_sec: int = int(os.getenv("METADATA_MAX_WAIT_SEC", "0"))  # 0 = wait indefinitely
     metadata_download_budget_bytes: int = int(os.getenv("METADATA_DOWNLOAD_BUDGET_BYTES", "0"))  # 0 = no cap
 
+    # Torrent age validation (to filter fake torrents with 0 age)
+    min_torrent_age_minutes: int = int(os.getenv("MIN_TORRENT_AGE_MINUTES", "0"))  # Minimum age in minutes; 0 = disabled (default)
+
     # Radarr (ISO deletes)
     radarr_url: str = (os.getenv("RADARR_URL", "http://127.0.0.1:7878") or "").rstrip("/")
     radarr_apikey: str = os.getenv("RADARR_APIKEY", "")
@@ -1336,6 +1339,42 @@ class TorrentGuard:
         # Stop immediately and tag
         self.qbit.stop(torrent_hash)
         self.qbit.add_tags(torrent_hash, "guard:stopped")
+
+        # Check torrent age (filter out fake torrents with 0 or very recent creation date)
+        if self.cfg.min_torrent_age_minutes > 0:
+            creation_date = info.get("creation_date")  # Unix timestamp
+            if creation_date:
+                torrent_age_seconds = time.time() - creation_date
+                torrent_age_minutes = torrent_age_seconds / 60.0
+                
+                if torrent_age_minutes < self.cfg.min_torrent_age_minutes:
+                    log.info("Torrent age check: BLOCKED (age=%.1f mins < minimum=%d mins). Likely fake torrent.",
+                            torrent_age_minutes, self.cfg.min_torrent_age_minutes)
+                    
+                    # Blocklist in Sonarr/Radarr if applicable
+                    if category_norm in self.cfg.sonarr_categories and self.sonarr.enabled:
+                        try: self.sonarr.blocklist_download(torrent_hash)
+                        except Exception as e: log.error("Sonarr blocklist error: %s", e)
+                    if category_norm in self.cfg.radarr_categories and self.radarr.enabled:
+                        try: self.radarr.blocklist_download(torrent_hash)
+                        except Exception as e: log.error("Radarr blocklist error: %s", e)
+                    
+                    # Tag and delete
+                    self.qbit.add_tags(torrent_hash, "trash:too-new")
+                    if not self.cfg.dry_run:
+                        try:
+                            self.qbit.delete(torrent_hash, self.cfg.delete_files)
+                            log.info("Removed torrent %s (too new/fake, age=%.1f mins).", torrent_hash, torrent_age_minutes)
+                        except Exception as e:
+                            log.error("qB delete failed: %s", e)
+                    else:
+                        log.info("DRY-RUN: would remove torrent %s (too new, age=%.1f mins).", torrent_hash, torrent_age_minutes)
+                    return
+                else:
+                    log.info("Torrent age check: PASSED (age=%.1f mins >= minimum=%d mins).",
+                            torrent_age_minutes, self.cfg.min_torrent_age_minutes)
+            else:
+                log.warning("Torrent age check: creation_date not available, skipping age validation.")
 
         # Tracker hosts (for whitelist decisions)
         trackers = self.qbit.trackers(torrent_hash) or []


### PR DESCRIPTION
Updated to add support for fake torrents with min age, 

configurable variable is now available 'MIN_TORRENT_AGE_MINUTES' to set desired age as min threshold.